### PR TITLE
Added main to package.json for building with Parcel

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "leaflet",
     "html5"
   ],
+  "main": "src/leaflet-compass.js",
   "dependencies": {
     "leaflet": "*"
   },


### PR DESCRIPTION
I was trying to use this repo with my project using Parcel to package. Without a `main` attribute in the package.json however the build failed as it couldn't find the entry point for compilation.