### PR TITLE
fix operation on iPhoneOS Safari

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2013-2020 Stefano Cudini
+Copyright (c) 2022 mirabilos
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/leaflet-compass.js
+++ b/src/leaflet-compass.js
@@ -43,7 +43,7 @@ L.Control.Compass = L.Control.extend({
 
 	initialize: function(options) {
 		if(options && options.style)
-			options.style = L.Util.extend({}, this.options.style, options.style); 
+			options.style = L.Util.extend({}, this.options.style, options.style);
 		L.Util.setOptions(this, options);
 		this._errorFunc = this.options.callErr || this.showAlert;
 		this._isActive = false;//global state of compass
@@ -54,8 +54,8 @@ L.Control.Compass = L.Control.extend({
 
 		var self = this;
 
-		this._map = map;	
-			
+		this._map = map;
+
 		var container = L.DomUtil.create('div', 'leaflet-compass');
 
 		this._button = L.DomUtil.create('span', 'compass-button', container);
@@ -82,9 +82,9 @@ L.Control.Compass = L.Control.extend({
 	},
 
 	onRemove: function(map) {
-		
+
 		this.deactivate();
-		
+
 		L.DomEvent
 			.off(this._button, 'click', L.DomEvent.stop, this)
 			.off(this._button, 'click', this._switchCompass, this);
@@ -111,7 +111,7 @@ L.Control.Compass = L.Control.extend({
 		else {
 			this._errorCompass({message: 'Orientation angle not found'});
 		}
-		
+
 		angle = Math.round(angle);
 
 		if(angle % this.options.angleOffset === 0)
@@ -130,7 +130,7 @@ L.Control.Compass = L.Control.extend({
 	},
 
 	setAngle: function(angle) {
-		
+
 		if(this.options.showDigit && !isNaN(parseFloat(angle)) && isFinite(angle))
 			this._digit.innerHTML = angle+'°';
 
@@ -139,22 +139,38 @@ L.Control.Compass = L.Control.extend({
 
 		this.fire('compass:rotated', {angle: angle});
 	},
-	
+
 	getAngle: function() {	//get last angle
 		return this._currentAngle;
 	},
 
-	activate: function() {
-
+	_activate: function () {
 		this._isActive = true;
 
 		L.DomEvent.on(window, 'deviceorientation', this._rotateHandler, this);
-		
+
 		L.DomUtil.addClass(this._button, 'active');
 	},
 
+	activate: function () {
+		if (typeof(DeviceOrientationEvent) !== 'undefined' &&
+		    typeof(DeviceOrientationEvent.requestPermission) === 'function') {
+			/* iPhoneOS, must ask interactively */
+			var that = this;
+			DeviceOrientationEvent.requestPermission().then(function (permission) {
+				if (permission === 'granted')
+					that._activate();
+				else
+					alert('Cannot activate compass: permission ' + permission);
+			    }, function (reason) {
+				alert('Error activating compass: ' + reason);
+			    });
+		} else
+			this._activate();
+	},
+
 	deactivate: function() {
-		
+
 		this.setAngle(0);
 
 		this._isActive = false;

--- a/src/leaflet-compass.js
+++ b/src/leaflet-compass.js
@@ -76,7 +76,7 @@ L.Control.Compass = L.Control.extend({
 		}, this);
 
 		if(this.options.autoActive)
-			this.activate();
+			this.activate(true);
 
 		return container;
 	},
@@ -152,7 +152,7 @@ L.Control.Compass = L.Control.extend({
 		L.DomUtil.addClass(this._button, 'active');
 	},
 
-	activate: function () {
+	activate: function (isAutoActivation) {
 		if (typeof(DeviceOrientationEvent) !== 'undefined' &&
 		    typeof(DeviceOrientationEvent.requestPermission) === 'function') {
 			/* iPhoneOS, must ask interactively */
@@ -160,10 +160,11 @@ L.Control.Compass = L.Control.extend({
 			DeviceOrientationEvent.requestPermission().then(function (permission) {
 				if (permission === 'granted')
 					that._activate();
-				else
+				else if (isAutoActivation !== true)
 					alert('Cannot activate compass: permission ' + permission);
 			    }, function (reason) {
-				alert('Error activating compass: ' + reason);
+				if (isAutoActivation !== true)
+					alert('Error activating compass: ' + reason);
 			    });
 		} else
 			this._activate();


### PR DESCRIPTION
contributing fix from my map experiment repo as requested by https://github.com/stefanocudini/leaflet-compass/issues/15#issuecomment-1348639017

fixes the situation for iPhoneOS; “should not” affect others, but I haven’t been able to test them much; my employer’s Samsung Android has it working in Google Chrome but showing just 0° on Firefox Fennec from F-Droid but I don’t think it was working there before?